### PR TITLE
fix: change duplicate arg name to port

### DIFF
--- a/src/plugin_atropos/args.py
+++ b/src/plugin_atropos/args.py
@@ -4,5 +4,5 @@ from dataclasses import dataclass
 @dataclass
 class AtroposArgs:
     atropos_server_host: str = "http://localhost"
-    atropos_server_host: int = 8000
+    atropos_server_port: int = 8000
 


### PR DESCRIPTION
There were two `host`. Changed to `port`